### PR TITLE
Upgrade to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,6 @@ inputs:
     required: false
     default: after-build
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
 


### PR DESCRIPTION
When I use `aktions/codeclimate-test-reporter` , I will get the following deprecation warning

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: aktions/codeclimate-test-reporter, aktions/codeclimate-test-reporter

c.f. https://github.com/sue445/chatwork_webhook_verify/actions/runs/3395862822

So I upgraded to node16.

This works on my repository

* https://github.com/sue445/chatwork_webhook_verify/pull/44
* https://github.com/sue445/chatwork_webhook_verify/actions/runs/3395906733